### PR TITLE
Enforce unique sequence for the multisig

### DIFF
--- a/test/mock_file_swap_client.js
+++ b/test/mock_file_swap_client.js
@@ -8,11 +8,11 @@ const logger = require('../common/logger');
 class MockTokenSwapClient {
 
     async sequenceNumber () {
-        return qAccount.sequence;
+        return qAccount.value.sequence;
     }
 
     async getAccountNumber () {
-        return qAccount;
+        return qAccount.value.accountNumber;
     }
 
     async isSwapDone (ethTxHash) {

--- a/test/mock_file_swap_client_unreliable.js
+++ b/test/mock_file_swap_client_unreliable.js
@@ -20,14 +20,14 @@ class MockTokenSwapClientUnreliable {
         if (this.fail) {
             throw new Error("mock fail")
         }
-        return qAccount.sequence;
+        return qAccount.value.sequence;
     }
 
     async getAccountNumber () {
         if (this.fail) {
             throw new Error("mock fail")
         }
-        return qAccount;
+        return qAccount.value.accountNumber;
     }
 
     async isSwapDone (ethTxHash) {


### PR DESCRIPTION
There's a condition where a transaction can fail, or be in progress, and another swap can be inserted with the same sequence number.
This enforces a unique sequence number for the account, so it still works if switching multisig in future.

Also prevents broadcast with a tx in progress, allowing failed and submitted txs to be finalized first.