### PR TITLE
Fix inserting duplicate sequence numbers for the account

### DIFF
--- a/common/db.js
+++ b/common/db.js
@@ -136,6 +136,21 @@ class Db {
     }
 
     /**
+     * Returns the next sequence number for the multisig account.
+     * @param accountNumber Multisig's account number
+     */
+    async getNextSequenceNumber (accountNumber) {        
+        const query = { accountNumber: parseInt(accountNumber) };
+        const result = await this.db.collection(SWAP_COLLECTION).find(query).limit(1).sort({sequence: -1});
+        const swaps = await result.toArray();
+        if (swaps.length === 1) {
+            return swaps[0].sequence + 1;
+        } else {
+            return 0;
+        }
+    }
+
+    /**
      * Find all by status.
      *
      * @returns {Promise<Array<Swap>>}

--- a/leader/index.js
+++ b/leader/index.js
@@ -59,7 +59,15 @@ class Leader {
     }
 
     async getSequence () {
-        return this.tokenSwapClient.sequenceNumber();
+        // first check mongodb and increment the last sequence
+        // if no sequence ever, ie new account, then only get sequence from blockchain
+        const accountNumber = await this.getAccountNumber();
+        const dbSequence = await this.db.getNextSequenceNumber(accountNumber);
+        if (dbSequence > 0) {
+            return dbSequence;
+        } else {
+            return this.tokenSwapClient.sequenceNumber();
+        }
     }
 
     async getAccountNumber () {

--- a/test/mock_file_swap_client.js
+++ b/test/mock_file_swap_client.js
@@ -12,7 +12,7 @@ class MockTokenSwapClient {
     }
 
     async getAccountNumber () {
-        return qAccount.value.accountNumber;
+        return qAccount.value.account_number;
     }
 
     async isSwapDone (ethTxHash) {

--- a/test/mock_file_swap_client_unreliable.js
+++ b/test/mock_file_swap_client_unreliable.js
@@ -27,7 +27,7 @@ class MockTokenSwapClientUnreliable {
         if (this.fail) {
             throw new Error("mock fail")
         }
-        return qAccount.value.accountNumber;
+        return qAccount.value.account_number;
     }
 
     async isSwapDone (ethTxHash) {

--- a/test/swap.test.leader.js
+++ b/test/swap.test.leader.js
@@ -155,6 +155,14 @@ describe('EngSwap', () => {
         expect(unsignedSwaps.length).to.equal(nbSwaps);
     });
 
+    it('...Next sequence should be based on DB, not blockchain.', async () => {
+        const sequenceNumber = await leader.getSequence();
+        expect(sequenceNumber).to.equal(nbSwaps);  // Sequence is zero indexed
+
+        const blockchainSequence = await leaderClient.sequenceNumber();
+        expect(blockchainSequence).to.equal('0');  // static but mocks nothing broadcast yet
+    });
+
     it('...should not broadcast new tx while failing any.', async () => {
         const unsignedSwaps = await db.findAboveThresholdUnsignedSwaps(2);
         expect(unsignedSwaps.length).to.equal(4);


### PR DESCRIPTION
In an edge case the leader can insert a swap, then fail to broadcast the TX (eg mongodb connection error lately), and if another swap is found on successful restart (connection restored), that swap will be inserted with the current blockchain sequence number, which has already been assigned but not broadcast yet.

This fix fetches the latest sequence from the DB on restart, and increments that for the new swap.